### PR TITLE
removed addsamplestobackground=TRUE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ENMeval
 Type: Package
-Title: Automated Tuning and Evaluations of Ecological Niche Models
+Title: Automated Tuning and Evaluations of Ecological Niche Models (enabled addsamplestobackground)
 Version: 2.0.4
 Date: 2022-05-19
 Authors@R: c(

--- a/R/ENMevaluate.R
+++ b/R/ENMevaluate.R
@@ -441,12 +441,12 @@ ENMevaluate <- function(occs, envs = NULL, bg = NULL, tune.args = NULL, partitio
       names(bg) <- names(occs)
     }
     
-    # remove cell duplicates
-    occs.cellNo <- raster::extract(envs, occs, cellnumbers = TRUE)
-    occs.dups <- duplicated(occs.cellNo[,1])
-    if(sum(occs.dups) > 0) if(quiet != TRUE) message(paste0("* Removed ", sum(occs.dups), " occurrence localities that shared the same grid cell."))
-    occs <- occs[!occs.dups,]
-    if(!is.null(user.grp)) user.grp$occs.grp <- user.grp$occs.grp[!occs.dups]
+    ## remove cell duplicates
+    #occs.cellNo <- raster::extract(envs, occs, cellnumbers = TRUE)
+    #occs.dups <- duplicated(occs.cellNo[,1])
+    #if(sum(occs.dups) > 0) if(quiet != TRUE) message(paste0("* Removed ", sum(occs.dups), " occurrence localities that shared the same grid cell."))
+    #occs <- occs[!occs.dups,]
+    #if(!is.null(user.grp)) user.grp$occs.grp <- user.grp$occs.grp[!occs.dups]
     
     # bind coordinates to predictor variable values for occs and bg
     occs.z <- raster::extract(envs, occs)

--- a/R/enm.maxnet.R
+++ b/R/enm.maxnet.R
@@ -36,9 +36,6 @@ maxnet.args <- function(occs.z, bg.z, tune.tbl.i, other.settings) {
   out$p <- c(rep(1, nrow(occs.z)), rep(0, nrow(bg.z)))
   out$f <- maxnet::maxnet.formula(out$p, out$data, classes = tolower(tune.tbl.i$fc))
   out$regmult <- tune.tbl.i$rm
-  # some models fail to converge if this parameter is not set to TRUE
-  # usually the case with sparse datasets
-  out$addsamplestobackground <- TRUE
   out <- c(out, other.settings$other.args)
   return(out)
 }


### PR DESCRIPTION
As "_maxnet has this set to TRUE as default_" it make no sense to force it TRUE without possibility to change it to FALSE (via `other.settings$other.args`). 

Currently, setting: 
`other.settings = list("addsamplestobackground" = FALSE)`  is overwritten and
`other.settings = list("other.args" = list("addsamplestobackground" = FALSE))` only add second (duplicite, same name) item, that wil not be considered.