### PR TITLE
vignette: avoid removing all occs if no NAs

### DIFF
--- a/vignettes/ENMeval-2.0-vignette.Rmd
+++ b/vignettes/ENMeval-2.0-vignette.Rmd
@@ -119,7 +119,7 @@ Now let's take a look at which areas of this extent are climatically different w
 # NA values for our environmental variable rasters.
 occs.z <- terra::extract(envs, occs, ID = FALSE)
 occs.na <- which(rowSums(is.na(occs.z)) > 0)
-occs <- occs[-occs.na,]
+if (length(occs.na) > 0) occs <- occs[-occs.na,]
 occs.z <- na.omit(occs.z)
 # Now we use the mess() function from the predicts pkg to calculate 
 # environmental similarity metrics of our predictor variable extent compared to 


### PR DESCRIPTION
If the user runs the original code on occurrence data with no NAs in the climatic variables (i.e. with zero `occs.na`), `occs[-occs.na, ]` returns and empty dataframe, because `occs[-0, ]` is the same as `occs[0, ]`. Adding this `if()` statement will avoid that, making the vignette code more reproducible for any dataset.