### PR TITLE
Add check and warning for wrong lat-long column

### DIFF
--- a/R/ENMevaluate.R
+++ b/R/ENMevaluate.R
@@ -342,6 +342,14 @@ ENMevaluate <- function(occs, envs = NULL, bg = NULL, tune.args = NULL,
   if(inherits(occs[,1], "character") | inherits(bg[,1], "character")) 
     stop("* If first column of input occurrence or background data is the taxon name, remove it and instead include the 'taxon.name' argument. The first two columns must be the longitude and latitude of the occurrence/background localities.")
   
+  # guess if long-lat columns are in wrong order and warn
+  nms <- tolower(names(occs))
+  if(grepl("lat", nms[1]) || nms[1] %in% "y" ||
+     grepl("lon", nms[2]) || nms[2] %in% "x") {
+    warning("Column names of 'occs' suggest latitude-longitude order: '", names(occs)[1], "', '", names(occs)[2],
+         "'.\n The expected order is logitude-latitude.")
+  }
+
   if(is.null(taxon.name)) {
     if(quiet != TRUE) message(paste0("*** Running initial checks... ***\n"))
   }else{
@@ -467,7 +475,7 @@ ENMevaluate <- function(occs, envs = NULL, bg = NULL, tune.args = NULL,
                               values = FALSE) |> as.data.frame()
       names(bg) <- names(occs)
     }
-
+    
     # remove cell duplicates
     if(other.settings$removeduplicates == TRUE) {
       occs.cellNo <- terra::extract(envs, occs, cells = TRUE, ID = FALSE)
@@ -482,20 +490,9 @@ ENMevaluate <- function(occs, envs = NULL, bg = NULL, tune.args = NULL,
     }else{
       occs.z <- terra::extract(envs, occs, ID = FALSE)  
     }
-
+    
     # bind coordinates to predictor variable values for occs and bg
     bg.z <- terra::extract(envs, bg, ID = FALSE)
-
-    # with cropped maps points can fall outside and produce empty data frames
-    if (all(is.na(occs.z)))
-      stop(paste0("All predictor variables for 'occs' are NAs. ",
-       "Check that coordinates are in longitude-latitude order and ",
-       "they fall inside the extent of 'envs'."))
-    if (all(is.na(bg.z)))
-      stop(paste0("All predictor variables for 'bg' are NAs. ",
-       "Check that coordinates are in longitude-latitude order and ",
-       "they fall inside the extent of 'envs'."))
-
     occs <- cbind(occs, occs.z)
     bg <- cbind(bg, bg.z)
   }else{

--- a/R/ENMevaluate.R
+++ b/R/ENMevaluate.R
@@ -467,7 +467,7 @@ ENMevaluate <- function(occs, envs = NULL, bg = NULL, tune.args = NULL,
                               values = FALSE) |> as.data.frame()
       names(bg) <- names(occs)
     }
-    
+
     # remove cell duplicates
     if(other.settings$removeduplicates == TRUE) {
       occs.cellNo <- terra::extract(envs, occs, cells = TRUE, ID = FALSE)
@@ -482,9 +482,20 @@ ENMevaluate <- function(occs, envs = NULL, bg = NULL, tune.args = NULL,
     }else{
       occs.z <- terra::extract(envs, occs, ID = FALSE)  
     }
-    
+
     # bind coordinates to predictor variable values for occs and bg
     bg.z <- terra::extract(envs, bg, ID = FALSE)
+
+    # with cropped maps points can fall outside and produce empty data frames
+    if (all(is.na(occs.z)))
+      stop(paste0("All predictor variables for 'occs' are NAs. ",
+       "Check that coordinates are in longitude-latitude order and ",
+       "they fall inside the extent of 'envs'."))
+    if (all(is.na(bg.z)))
+      stop(paste0("All predictor variables for 'bg' are NAs. ",
+       "Check that coordinates are in longitude-latitude order and ",
+       "they fall inside the extent of 'envs'."))
+
     occs <- cbind(occs, occs.z)
     bg <- cbind(bg, bg.z)
   }else{


### PR DESCRIPTION
This is related to #180 , since wrong order was the underlying problem there. 

Currently there is no check for longitude and latitude order. There is no formal way of checking using the numeric vectors, so the best guess is to see the column names, similar to `.checkXYnames` in `terra::vect` ([code here](https://github.com/rspatial/terra/blob/b15cefcf97b32af522de5999f7ff7a9039ad4007/R/vect.R#L178)).

This patch warns if the column names seems wrong. It doesn't stop the program since it may produce false positives.

All the tests passed and manual testing of this works. 